### PR TITLE
Compile OpenLDAP using FIPS-enabled OpenSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Use a builder image for OpenLDAP compiled with FIPS-enabled OpenSSL. This is
+  included in the Phusion Ruby base image for the DAP appliance
+  ([cyberark/conjur-base-image#10](https://github.com/cyberark/conjur-base-image/pull/10))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,11 @@ pipeline {
             sh "./postgres-client-builder/build.sh"
           }
         }
+        stage ('Build and tag openldap-builder image') {
+          steps {
+            sh "./phusion-openldap-builder/build.sh"
+          }
+        }
       }
     }
     stage ('Build and Test fips base images') {

--- a/dev/phusion-ruby-fips.sh
+++ b/dev/phusion-ruby-fips.sh
@@ -8,4 +8,6 @@ cd "$(dirname "$0")"
 
 ../postgres-client-builder/build.sh
 
+../phusion-openldap-builder/build.sh
+
 ../phusion-ruby-fips/build.sh dev

--- a/phusion-openldap-builder/Dockerfile
+++ b/phusion-openldap-builder/Dockerfile
@@ -1,0 +1,53 @@
+ARG PHUSION_VERSION
+ARG OPENSSL_BUILDER_TAG
+ARG OPENLDAP_VERSION
+
+
+FROM openssl-builder:$OPENSSL_BUILDER_TAG as OpenSSL-builder
+
+FROM phusion/baseimage:$PHUSION_VERSION
+ENV PATH="/usr/local/ssl/bin:${PATH}" \
+    LD_LIBRARY_PATH="/usr/local/ssl/lib" \
+    OPENSSL_FIPS=1
+
+COPY --from=OpenSSL-builder /usr/local/ssl/ /usr/local/ssl/
+
+# Install the dependencies for OpenLDAP with OpenSSL
+RUN DEBIAN_FRONTEND=noninteractive  apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y devscripts wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get build-dep -y libldap2-dev
+
+# OpenLDAP 2.4.46 is the earliest version to support OpenSSL 1.1.1,
+# which is included with phusion/baseimage:0.11
+ARG OPENLDAP_VERSION
+ARG openldap_base_url=https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/openldap/${OPENLDAP_VERSION}+dfsg-5ubuntu1.2
+
+ARG ORIGINAL_SRC_SHA256=e93cb511f6bce162c27502d0d240e6410a8f14e72c47ddddb4e69b25b7c538e4
+ARG DEBIAN_SRC_SHA256=b727928852dd03fc7cc7587b2623c2e206e6bbc11447dfcb2f7f7749a068e5f3
+
+RUN cd /root && \
+    #
+    # The openldap source in the debian packages for 0.11 are for 2.4.45, so we pull
+    # the source for 2.4.46 using direct links:
+    wget -q ${openldap_base_url}/openldap_${OPENLDAP_VERSION}+dfsg.orig.tar.gz &&\
+    echo "$ORIGINAL_SRC_SHA256 openldap_${OPENLDAP_VERSION}+dfsg.orig.tar.gz" | sha256sum -c - && \
+    tar -xvf openldap_${OPENLDAP_VERSION}+dfsg.orig.tar.gz && \
+    #
+    # Download the debian src diffs for openldap
+    wget -q ${openldap_base_url}/openldap_${OPENLDAP_VERSION}+dfsg-5ubuntu1.2.debian.tar.xz && \
+    echo "$DEBIAN_SRC_SHA256 openldap_${OPENLDAP_VERSION}+dfsg-5ubuntu1.2.debian.tar.xz" | sha256sum -c - && \
+    cat openldap_${OPENLDAP_VERSION}+dfsg-5ubuntu1.2.debian.tar.xz | tar -xJv --directory ./openldap-* && \
+    #
+    # Once the debian packages include >= 2.4.46, the following line may be used to pull
+    # the source for openldap instead:
+    # && DEBIAN_FRONTEND=noninteractive apt-get source -y openldap \
+    #
+    # Build the openldap debian packages using openssl rather than gnutls
+    cd openldap-* &&\
+    env CC=gcc CPPFLAGS=-I/usr/local/ssl/include LDFLAGS=-L/usr/local/ssl/lib \
+      ./configure --with-tls=openssl --prefix=/usr/local/openldap ; \
+      make depend ; \
+      make; \
+      make install
+
+

--- a/phusion-openldap-builder/build.sh
+++ b/phusion-openldap-builder/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+PHUSION_VERSION=0.11
+OPENLDAP_VERSION=2.4.46
+OPENSSL_BUILDER_TAG=1.0.2u-fips-2.0.16
+
+docker build -t phusion-openldap-builder:"$OPENLDAP_VERSION-fips" \
+  --build-arg PHUSION_VERSION="$PHUSION_VERSION" \
+  --build-arg OPENLDAP_VERSION="$OPENLDAP_VERSION" \
+  --build-arg OPENSSL_BUILDER_TAG="$OPENSSL_BUILDER_TAG" \
+  .

--- a/phusion-ruby-fips/Dockerfile
+++ b/phusion-ruby-fips/Dockerfile
@@ -2,12 +2,14 @@ ARG PHUSION_VERSION
 ARG OPENSSL_BUILDER_TAG
 ARG RUBY_BUILDER_TAG
 ARG PG_BUILDER_TAG
+ARG OPENLDAP_BUILDER_TAG
 ARG BUNDLER_VERSION=2.1.4
 
 # OpenSSL, ruby and postgres-client Builders
 FROM openssl-builder:$OPENSSL_BUILDER_TAG as OpenSSL-builder
 FROM phusion-ruby-builder:$RUBY_BUILDER_TAG as phusion-ruby-builder
 FROM postgres-client-builder:$PG_BUILDER_TAG as postgres-client-builder
+FROM phusion-openldap-builder:$OPENLDAP_BUILDER_TAG as openldap-builder
 
 # Conjur Base Image (Phusion)
 FROM phusion/baseimage:$PHUSION_VERSION
@@ -18,8 +20,7 @@ RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y libreadline-dev
 
-RUN apt-get purge -y --auto-remove openssl libssl1.1
-
+RUN apt-get purge -y --auto-remove openssl libssl1.1 libldap-2.4-2
 # Install the FIPS compliant OpenSSL
 ## Copy to binary from openssl builder
 COPY --from=OpenSSL-builder /usr/local/ssl/ /usr/local/ssl/
@@ -43,12 +44,17 @@ RUN apt-mark hold openssl
 RUN apt-mark hold libssl1.0.0
 RUN apt-mark hold libssl1.1
 
+# Install SASL dependency for OpenLDAP  
+RUN apt-get install -y libsasl2-dev && \
+    apt-mark hold libssl1.1
+
 ## Copy postgres and ruby binaries from builders
 RUN mkdir -p /var/lib/pgsql/ /var/lib/ruby/
 COPY --from=postgres-client-builder /usr/local/pgsql/ /usr/local/pgsql/
 COPY --from=phusion-ruby-builder /var/lib/ruby/ /var/lib/ruby/
+COPY --from=openldap-builder /usr/local/openldap/ /usr/local/openldap/
 
-ENV PATH="/usr/local/pgsql/bin:/var/lib/ruby/bin:/usr/local/ssl/bin:${PATH}" \
+ENV PATH="/usr/local/openldap/bin:/usr/local/pgsql/bin:/var/lib/ruby/bin:/usr/local/ssl/bin:${PATH}" \
     LD_LIBRARY_PATH="/usr/local/ssl/lib" \
     OPENSSL_FIPS=1
 

--- a/phusion-ruby-fips/build.sh
+++ b/phusion-ruby-fips/build.sh
@@ -6,6 +6,7 @@ PHUSION_VERSION=0.11
 OPENSSL_BUILDER_TAG=1.0.2u-fips-2.0.16
 RUBY_BUILDER_TAG=2.5.1-fips
 PG_BUILDER_TAG=12-12.2-fips
+OPENLDAP_BUILDER_TAG=2.4.46-fips
 IMAGE_TAG=$1
 
 docker build -t phusion-ruby-fips:"$IMAGE_TAG" \
@@ -13,4 +14,5 @@ docker build -t phusion-ruby-fips:"$IMAGE_TAG" \
   --build-arg OPENSSL_BUILDER_TAG="$OPENSSL_BUILDER_TAG" \
   --build-arg RUBY_BUILDER_TAG="$RUBY_BUILDER_TAG" \
   --build-arg PG_BUILDER_TAG="$PG_BUILDER_TAG" \
+  --build-arg OPENLDAP_BUILDER_TAG="$OPENLDAP_BUILDER_TAG" \
   .


### PR DESCRIPTION
### What does this PR do?
_What's changed? Why were these changes made?_

Previously we compiled OpenLDAP in the DAP container build, so that it uses OpenSSL rather than gnuTLS. To use the FIPS-enabled OpenSSL version instead, we move the OpenLDAP build to this repository, and add the build artifacts to the FIPS base image.

_How should the reviewer approach this PR, especially if manual tests are required?_

There are several builds in the chain to verify this fix:

  * [ Appliance build including this base image](https://github.com/conjurinc/appliance/tree/compile-ldap-openssl)
  * [Debify version that consumes this base image](https://github.com/conjurinc/debify/tree/update-conjur-img)
  * [LDAP Sync build that uses this appliance build](https://jenkins.conjur.net/job/conjurinc--ldap-sync/job/update-debify-img/)

### What ticket does this PR close?
Connected to [ldap-sync#156](https://github.com/conjurinc/ldap-sync/issues/156)

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
