### PR TITLE
Test openldap libs linkage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
 
 def buildAndTestImage(name) {
   sh "./${name}/build.sh ${TAG}"
-  sh "./test.sh --full-image-name ${name}:${TAG} --test-file-name test.yml"
+  sh "./${name}/test.sh ${TAG}"
   scanAndReport("${name}:${TAG}", "HIGH", false)
   scanAndReport("${name}:${TAG}", "NONE", true)
 }

--- a/phusion-ruby-fips/test.sh
+++ b/phusion-ruby-fips/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")"
+
+IMAGE_TAG=$1
+
+# run common tests
+../test.sh --full-image-name phusion-ruby-fips:"$IMAGE_TAG" --test-file-name test.yml
+
+# run phusion specific tests
+../test.sh --full-image-name phusion-ruby-fips:"$IMAGE_TAG" --test-file-name phusion-ruby-fips/test.yml

--- a/phusion-ruby-fips/test.yml
+++ b/phusion-ruby-fips/test.yml
@@ -1,0 +1,19 @@
+schemaVersion: 2.0.0
+commandTests:
+  # openldap tests
+  - name: "open ldap libs are linked to the valid openssl version"
+    setup: [["apt-get", "update"], ["apt-get", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - > 
+       find / -name libl*.*so* -type f |
+       grep openldap |
+       xargs ldd |
+       grep "lib\(ssl\|crypto\).so" |
+       cut -d' ' -f3 |
+       sort | uniq |
+       xargs strings |
+       grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" |
+       sort | uniq | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.0.2u-fips  20 Dec 2019$"]

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+cd "$(dirname "$0")"
+
 FULL_IMAGE_NAME=""
 TEST_FILE_NAME=""
 
@@ -24,7 +26,7 @@ if [ "$TEST_FILE_NAME" == "" ]; then
   exit 1
 fi
 
-REPORT_FILE_NAME="$(echo $FULL_IMAGE_NAME | cut -d':' -f1 | tr '/' '-').json"
+REPORT_FILE_NAME="$(echo $(echo $FULL_IMAGE_NAME | cut -d':' -f1).$(echo $TEST_FILE_NAME | tr -d '.') | tr '/' '-').json"
 
 mkdir -p test-results
 

--- a/test.yml
+++ b/test.yml
@@ -35,16 +35,16 @@ commandTests:
       - /etc/passwd
     exitCode: 1
     expectedError: [".*disabled for fips.*"]
-  - name: "openssl vertion is on hold"
-    setup: [["apt-get", "update"]]
-    command: "apt-get"
+  # holded packages
+  - name: "packages are on hold"
+    command: "apt-mark"
     args:
-      - "install"
-      - "-y"
-      - "openssl"
-    exitCode: 100
-    expectedOutput: [ ".*libssl.*is not going to be installed.*" ]
-    expectedError: [ ".*you have held broken packages.*" ]
+      - "showhold"
+    expectedOutput:
+      - ".*ca-certificates.*"
+      - ".*libssl1.0.0.*"
+      - ".*libssl1.1.*"
+      - ".*openssl.*"
   # ruby tests
   - name: "Ruby linked with valid libcrypto.so version"
     setup: [["apt-get", "update"], ["apt-get", "install", "-y", "binutils"]]

--- a/ubuntu-ruby-fips/test.sh
+++ b/ubuntu-ruby-fips/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")"
+
+IMAGE_TAG=$1
+
+# run common tests
+../test.sh --full-image-name ubuntu-ruby-fips:"$IMAGE_TAG" --test-file-name test.yml


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

Following #10 PR test that validates openldap libs are linked to the proper openssl has been added to `phusion-ruby-fips` image.
This test is the first test that runs on particular image and no on both of them so light test scripts refactor has been done.

In addition test validates package holding has been rewritten in more explicit manner.
### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
