### PR TITLE
Disable building Ruby documents and static ruby library

### DIFF
--- a/phusion-ruby-builder/Dockerfile
+++ b/phusion-ruby-builder/Dockerfile
@@ -33,6 +33,6 @@ RUN wget --quiet https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR_VERSION/ruby-$
     echo "$RUBY_SHA256 ruby-$RUBY_FULL_VERSION.tar.gz" | sha256sum -c - && \
     tar -xvf ruby-$RUBY_FULL_VERSION.tar.gz && \
     cd ruby-$RUBY_FULL_VERSION && \
-    ./configure --with-openssl-dir=/usr/local/ssl --prefix=/var/lib/ruby && \
+    ./configure --with-openssl-dir=/usr/local/ssl --disable-install-doc --disable-install-rdoc --disable-install-capi --enable-shared --prefix=/var/lib/ruby && \
     make -j4 && \
     make install


### PR DESCRIPTION
### What does this PR do?
add the following options to the ruby installation:
--disable-install-doc - do not install either rdoc indexes or C API documents during install.
--disable-install-rdoc - do not install rdoc indexes during install.
--disable-install-capi - do not install C API documents during install.
--enable-shared -  enables building of the libruby shared library.

### What ticket does this PR close?
#16 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
