### PR TITLE
UBI Ruby builder image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- UBI-based image to support Conjur server running on OpenShift. Uses a builder image to install Ruby 
+  compiled with FIPS-enabled OpenSSL.
+  ([cyberark/conjur-base-image#34](https://github.com/cyberark/conjur-base-image/pull/34))
+
 - Use a builder image for OpenLDAP compiled with FIPS-enabled OpenSSL. This is
   included in the Phusion Ruby base image for the DAP appliance
   ([cyberark/conjur-base-image#10](https://github.com/cyberark/conjur-base-image/pull/10))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,11 @@ pipeline {
             sh "./ubuntu-ruby-builder/build.sh"
           }
         }
+        stage ('Build and push ubi-ruby-builder image') {
+          steps {
+            sh "./ubi-ruby-builder/build.sh"
+          }
+        }
         stage ('Build and tag postgres-client-builder image') {
           steps {
             sh "./postgres-client-builder/build.sh"
@@ -56,12 +61,18 @@ pipeline {
             buildTestAndScanImage('ubuntu-ruby-fips')
           }
         }
+        stage ('Build, Test, and Scan ubi-ruby-fips image') {
+          steps {
+            buildTestAndScanImage('ubi-ruby-fips')
+          }
+        }
       }
     }
     stage ('Push images') {
       steps {
         sh "./phusion-ruby-fips/push.sh ${TAG} registry.tld"
         sh "./ubuntu-ruby-fips/push.sh ${TAG} registry.tld"
+        sh "./ubi-ruby-fips/push.sh ${TAG} registry.tld"
       }
     }
     stage ('Publish images') {
@@ -75,6 +86,7 @@ pipeline {
       steps {
         sh "./phusion-ruby-fips/push.sh ${TAG}"
         sh "./ubuntu-ruby-fips/push.sh ${TAG}"
+        sh "./ubi-ruby-fips/push.sh ${TAG}"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 
 This repo builds a Docker image that contains OpenSSL, Ruby and PostgreSQL client libraries compiled against the FIPS 140-2 compliant OpenSSL module.
 
-Two images included:
+Three images included:
 - [Phusion](./phusion-ruby-fips/) 
 - [Ubuntu](./ubuntu-ruby-fips/) 
+- [UBI](./ubi-ruby-fips/)
 
 ## Certification level
 
@@ -34,14 +35,17 @@ work with Conjur OSS as documented. For more detailed information on our certifi
 * Last security update
 * Jenkins pipeline for building the Docker image
 * Automated tests validate FIPS mode is successfully enabled and all artifacts are compiled against the FIPS 140-2 compliant
-* One OpenSSL version installed in the image:
+* OpenSSL version installed in the Phusion and Ubuntu images:
   * OpenSSL version: `openssl-1.0.2u`
   * OpenSSL FIPS Module version: `openssl-fips-2.0.16`
+* OpenSSL version installed in the UBI image:
+  * OpenSSL version: `openssl-1.1.1c`
   
 ## Usage
 
 - [Phusion](./phusion-ruby-fips/) image is the parent image of DAP Server
-- [Ubuntu](./ubuntu-ruby-fips/) image is the parent image of Conur Server
+- [Ubuntu](./ubuntu-ruby-fips/) image is the parent image of Conjur Server
+- [UBI](./ubi-ruby-fips/) image is the parent image of Conjur Server for OpenShift
 
 ## What is FIPS 140-2
 

--- a/test-ubi.yml
+++ b/test-ubi.yml
@@ -1,0 +1,90 @@
+schemaVersion: 2.0.0
+commandTests:
+  # OpenSSL tests
+  - name: "OpenSSL version"
+    command: "openssl"
+    args: ["version"]
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019\n$"]
+  - name: "libssl.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -type f -name libssl.so* -exec strings {} \; | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "libcrypto.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -type f -name libcrypto.so* -exec strings {} \; | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "OpenSSL accepts FIPS compliant algorithms"
+    command: "openssl"
+    args:
+      - sha256
+      - /etc/passwd
+  # ruby tests
+  - name: "Ruby linked with valid libcrypto.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -name *ssl*.*so* | grep ruby | xargs ldd | grep "libcrypto.so" | cut -d' ' -f3 | xargs strings | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "Ruby linked with valid libssl.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -name *ssl*.*so* | grep ruby | xargs ldd | grep "libssl.so" | cut -d' ' -f3 | xargs strings | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "Ruby sees valid OpenSSL version"
+    command: "ruby"
+    args:
+      - -ropenssl
+      - -e
+      - 'puts OpenSSL::OPENSSL_LIBRARY_VERSION'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019\n$"]
+  - name: "Ruby accepts FIPS compliant algorithms"
+    command: "ruby"
+    args:
+      - -ropenssl
+      - -e
+      - 'OpenSSL.fips_mode = true'
+      - -e
+      - 'puts(OpenSSL::Digest::SHA256.new)'
+  - name: "Ruby denies FIPS compliant algorithms"
+    command: "ruby"
+    args:
+      - -ropenssl
+      - -e
+      - 'OpenSSL.fips_mode = true'
+      - -e
+      - 'puts(OpenSSL::Digest::MD5.new)'
+    exitCode: 1
+    expectedError: [".*disabled for FIPS.*"]
+  # postgres client tests
+  - name: "libpq linked with valid libcrypto.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -type f -name libpq.so* | xargs ldd | grep "libcrypto.so" | cut -d' ' -f3 | xargs strings | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "libpq linked with valid libssl.so version"
+    setup: [["yum", "install", "-y", "binutils"]]
+    command: "bash"
+    args:
+      - -c
+      - find / -type f -name libpq.so* | xargs ldd | grep "libssl.so" | cut -d' ' -f3 | xargs strings | grep "^OpenSSL\s\([0-9]\.\)\{2\}[0-9]" | tr -d '\n'
+    expectedOutput: ["^OpenSSL 1.1.1c FIPS  28 May 2019$"]
+  - name: "Postgres version"
+    command: "pg_dump"
+    args: ["--version"]
+    expectedOutput: ["^pg_dump \\(PostgreSQL\\) 10.14\n$"]
+  # bundler tests
+  - name: "bundler version"
+    command: "bundler"
+    args: ["--version"]
+    expectedOutput: ["^Bundler version 2.1.4\n$"]

--- a/ubi-ruby-builder/Dockerfile
+++ b/ubi-ruby-builder/Dockerfile
@@ -1,0 +1,28 @@
+# Declare UBI and Ruby versions
+ARG UBI_VERSION
+ARG RUBY_MAJOR_VERSION
+ARG RUBY_FULL_VERSION
+
+# Ruby Builder
+FROM registry.access.redhat.com/$UBI_VERSION/ubi
+ARG RUBY_MAJOR_VERSION
+ARG RUBY_FULL_VERSION
+ARG RUBY_SHA256=6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a
+
+RUN yum install -y --setopt=tsflags=nodocs gcc \
+                                           gcc-c++ \
+                                           make \
+                                           openssl-devel \
+                                           wget \
+                                           zlib-devel
+RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm
+
+
+## Compile ruby
+RUN wget --quiet https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR_VERSION/ruby-$RUBY_FULL_VERSION.tar.gz && \
+    echo "$RUBY_SHA256 ruby-$RUBY_FULL_VERSION.tar.gz" | sha256sum -c - && \
+    tar -xvf ruby-$RUBY_FULL_VERSION.tar.gz && \
+    cd ruby-$RUBY_FULL_VERSION && \
+    ./configure --prefix=/var/lib/ruby && \
+    make -j4 && \
+    make install

--- a/ubi-ruby-builder/build.sh
+++ b/ubi-ruby-builder/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+UBI_VERSION=ubi8
+RUBY_MAJOR_VERSION=2.5
+RUBY_FULL_VERSION=2.5.8
+
+docker build -t ubi-ruby-builder:"$RUBY_FULL_VERSION-fips" \
+  --build-arg UBI_VERSION="$UBI_VERSION" \
+  --build-arg RUBY_MAJOR_VERSION="$RUBY_MAJOR_VERSION" \
+  --build-arg RUBY_FULL_VERSION="$RUBY_FULL_VERSION" \
+  .

--- a/ubi-ruby-fips/Description.md
+++ b/ubi-ruby-fips/Description.md
@@ -1,0 +1,11 @@
+# ubi-ruby-fips
+ `ubi-ruby-fips` combines a [base UBI image](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e) 
+ with Ruby compiled against the FIPS 140-2 compliant [OpenSSL module](https://www.openssl.org/docs/fips.html).  
+This image includes the following packages:
+
+* OpenSSL version `1.1.1c`: with FIPS 140-2 compliant OpenSSL module from RedHat UBI 8.
+* Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.14`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Bundler version `2.1.4`.
+ 
+Source code: https://github.com/cyberark/conjur-base-image

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -1,0 +1,25 @@
+ARG UBI_VERSION
+ARG RUBY_BUILDER_TAG
+ARG BUNDLER_VERSION=2.1.4
+
+# Ruby Builder
+FROM ubi-ruby-builder:$RUBY_BUILDER_TAG as ubi-ruby-builder
+
+# Conjur Base Image (UBI)
+FROM registry.access.redhat.com/$UBI_VERSION/ubi
+ARG BUNDLER_VERSION
+
+### We need libreadline-dev for its readline capabilities
+RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
+### Install openssl, postgresql client
+    yum install -y openssl && \
+    yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
+    yum install -y postgresql10
+
+## Copy ruby binaries from ubi-ruby-builder
+RUN mkdir -p /var/lib/ruby/
+COPY --from=ubi-ruby-builder /var/lib/ruby/ /var/lib/ruby/
+ENV PATH="/var/lib/ruby/bin:${PATH}"
+
+## Install Ruby tools
+RUN gem install --no-document bundler:$BUNDLER_VERSION

--- a/ubi-ruby-fips/README.md
+++ b/ubi-ruby-fips/README.md
@@ -1,0 +1,37 @@
+# UBI container image
+This container image includes UBI version `8` which contains the following packages:
+
+* OpenSSL version `1.1.1c`: with FIPS 140-2 compliant OpenSSL module from RedHat UBI 8.
+* Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.14`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Bundler version `2.1.4`.
+ 
+
+## Build steps
+#### Assumptions
+
+1. Current directory is the directory where this repository is cloned
+1. Docker version is 17.05 or higher
+
+
+### Docker images    
+| Image name  | Description |
+|---|---|
+| ubi-ruby-builder | Installs Ruby version |
+| ubi-ruby | Final image |
+
+
+### Steps
+
+Create image for ubi-ruby-builder:
+```
+./ubi-ruby-builder/build.sh
+```
+Create the final image:
+
+$IMAGE_NAME is assumed to be the required name of Docker image
+
+$IMAGE_TAG is assumed to be the required tag of Docker image
+```
+docker build -t "$IMAGE_NAME":"$IMAGE_TAG" ubi-ruby
+```

--- a/ubi-ruby-fips/build.sh
+++ b/ubi-ruby-fips/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+UBI_VERSION=ubi8
+RUBY_BUILDER_TAG=2.5.8-fips
+IMAGE_TAG=$1
+
+docker build -t ubi-ruby-fips:"$IMAGE_TAG" \
+  --build-arg UBI_VERSION="$UBI_VERSION" \
+  --build-arg RUBY_BUILDER_TAG="$RUBY_BUILDER_TAG" \
+  .

--- a/ubi-ruby-fips/push.sh
+++ b/ubi-ruby-fips/push.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")"
+
+. ../push.sh
+
+UBI_VERSION=ubi8
+
+if [ "$BRANCH_NAME" = "master" ]; then
+  tag_and_push "ubi-ruby-fips:$1" "registry.tld/cyberark/ubi-ruby-fips:$UBI_VERSION-$1"
+  
+  repoName="$(normalize_repo_name $2)cyberark"
+  master_tag_and_push "ubi-ruby-fips:$1" "$repoName/ubi-ruby-fips" "$UBI_VERSION"
+else
+  tag_and_push "ubi-ruby-fips:$1" "registry.tld/cyberark/ubi-ruby-fips:$UBI_VERSION-$1"
+fi

--- a/ubi-ruby-fips/test.sh
+++ b/ubi-ruby-fips/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")"
+
+IMAGE_TAG=$1
+
+# run common tests
+../test.sh --full-image-name ubi-ruby-fips:"$IMAGE_TAG" --test-file-name test-ubi.yml


### PR DESCRIPTION
### Summary
It seems that openssl version that comes out of the box from the ubi base os repo is already FIPS compliance:
https://www.redhat.com/en/blog/how-rhel-8-designed-fips-140-2-requirements
We need to figure out if the Postgres client that we install using dnf/yum is FIPS as well as it will use the openssl within the os.

### What does this PR do?
- Add support to build ruby from source on UBI base image

### What ticket does this PR close?
Resolves #35 

### Checklists
- [x] Add new tests for ubi

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
