### PR TITLE
Fix Nginx publish stage link to secrets.yml

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -15,7 +15,7 @@ tag_and_push "ubi-nginx:${tag}" "registry.tld/cyberark/ubi-nginx:${NGINX_VERSION
 
 if [ -z "${repo_name}" ]; then
   # Publish production images
-  if summon bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
+  if summon -f ../secrets.yml bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
     master_tag_and_push "ubi-nginx:${tag}" "${REDHAT_IMAGE}" "${NGINX_VERSION}"
   else
     echo 'Failed to log in to scan.connect.redhat.com'


### PR DESCRIPTION
### What does this PR do?
Previously the secrets.yml file location wasn't explicitly specified in the
Summon command, but it was not present in the directory from which the command
was being run. This commit updates the summon command to point to the correct
secrets.yml file.

Before this change, I ran:
```
./ubi-nginx/push.sh "c99d8c6"
Tagging and pushing registry.tld/cyberark/ubi-nginx:1.14-c99d8c6...
open secrets.yml: no such file or directory
Failed to log in to scan.connect.redhat.com
```

After this change:
```
./ubi-nginx/push.sh "c99d8c6"
Tagging and pushing registry.tld/cyberark/ubi-nginx:1.14-c99d8c6...
Error fetching variable REDHAT_API_KEY: exit status 1: 403: Invalid permissions on 'redhat/projects/conjur-nginx/api-key'
Failed to log in to scan.connect.redhat.com
```

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
