### PR TITLE
Refer to Nginx image in release instrux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ to publish new versions of the image to public registries:
    - Copy the changelog from the new version into the GitHub release description.
    - The pipeline will automatically publish images to public image registries
      in the tag-triggered build.
-   - Visit the [Red Hat project page](https://connect.redhat.com/project/5899501/view)
+   - Visit the [Nginx Red Hat project page](https://connect.redhat.com/project/5899451/view)
      once the images have been pushed and manually choose to publish the latest
      release.
 1. Update the Dockerfiles in the Conjur project to point to the new base image


### PR DESCRIPTION
### What does this PR do?
Previously this project linked to the Conjur RH image page to publish on release, but that image is not published from this project.

This commit updates the CONTRIB instrux to refer to the Nginx image, which is the image published by this project.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
