### PR TITLE
Switch Postgres version to 10.16

### DIFF
--- a/phusion-ruby-fips/Description.md
+++ b/phusion-ruby-fips/Description.md
@@ -5,7 +5,7 @@ This image includes the following packages:
 
 * OpenSSL version `1.0.2u`: built with  FIPS 140-2 compliant OpenSSL module version `2.0.16`.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * OpenLDAP version `2.4.46`: built using OpenSSL rather than gnutls and compiled against the FIPS 140-2 compliant OpenSSL module. 
 * Bundler version `2.1.4`.
  

--- a/phusion-ruby-fips/README.md
+++ b/phusion-ruby-fips/README.md
@@ -3,7 +3,7 @@ This container image includes Phusion version `0.11` which contains the followin
 
 * OpenSSL version `1.0.2u`: built with  FIPS 140-2 compliant OpenSSL module version: `2.0.16`.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * OpenLDAP version `2.4.46`: built using openssl rather than gnutls and compiled against the FIPS 140-2 compliant OpenSSL module.
 * Bundler version `2.1.4`.
  

--- a/phusion-ruby-fips/build.sh
+++ b/phusion-ruby-fips/build.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 PHUSION_VERSION=0.11
 OPENSSL_BUILDER_TAG=1.0.2u-fips-2.0.16
 RUBY_BUILDER_TAG=2.5.8-fips
-PG_BUILDER_TAG=10-10.17-fips
+PG_BUILDER_TAG=10-10.16-fips
 OPENLDAP_BUILDER_TAG=2.4.46-fips
 
 docker build -t phusion-ruby-fips:latest \

--- a/postgres-client-builder/Dockerfile
+++ b/postgres-client-builder/Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && \
 # Postgres for Ubuntu 20.04 comes from a external repository
 RUN wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
     apt-key add ACCC4CF8.asc && \
-    echo "deb-src http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" >> /etc/apt/sources.list.d/pgdg.list && \
+    echo "deb-src https://apt-archive.postgresql.org/pub/repos/apt focal-pgdg-archive main" >> /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
-    apt-get source postgresql-10
+    apt-get source postgresql-10=10.16-1.pgdg20.04+1
 
 ## Compile postgres client
 #

--- a/postgres-client-builder/build.sh
+++ b/postgres-client-builder/build.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "$0")"
 
-PG_VERSION=10-10.17
+PG_VERSION=10-10.16
 OPENSSL_BUILDER_TAG=1.0.2u-fips-2.0.16
 
 docker build -t postgres-client-builder:"$PG_VERSION-fips" \

--- a/test.yml
+++ b/test.yml
@@ -103,7 +103,7 @@ commandTests:
   - name: "Postgres version"
     command: "pg_dump"
     args: ["--version"]
-    expectedOutput: ["^pg_dump \\(PostgreSQL\\) 10.17\n$"]
+    expectedOutput: ["^pg_dump \\(PostgreSQL\\) 10.16\n$"]
   # bundler tests
   - name: "bundler version"
     command: "bundler"

--- a/ubi-ruby-fips/Description.md
+++ b/ubi-ruby-fips/Description.md
@@ -5,7 +5,7 @@ This image includes the following packages:
 
 * OpenSSL version `1.1.1c`: with FIPS 140-2 compliant OpenSSL module from RedHat UBI 8.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * Bundler version `2.1.4`.
  
 Source code: https://github.com/cyberark/conjur-base-image

--- a/ubuntu-ruby-fips/build.sh
+++ b/ubuntu-ruby-fips/build.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 UBUNTU_VERSION=20.04
 OPENSSL_BUILDER_TAG=1.0.2u-fips-2.0.16
 RUBY_BUILDER_TAG=2.5.8-fips
-PG_BUILDER_TAG=10-10.17-fips
+PG_BUILDER_TAG=10-10.16-fips
 
 docker build -t ubuntu-ruby-fips:latest \
   --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" \


### PR DESCRIPTION
…10.16

### What does this PR do?
- _What's changed? Why were these changes made?_
This pull request pins the Postgres version to 10.16 in order to match the docker version of Conjur
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_
No

### What ticket does this PR close?
Resolves #1650

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
