### PR TITLE
Fix ubi-ruby-fips Postgres client version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Rolled back Postgres client version, in UBI-based image, back to 10.16 to match Conjur 
+  [cyberark/conjur-base-image#62](https://github.com/cyberark/conjur-base-image/pull/62)
+
 ## [1.0.4] - 2021-07-22
 
 - Upgraded ubi8 base image to resolve [CVE-2021-33910](https://nvd.nist.gov/vuln/detail/CVE-2021-33910)

--- a/test-ubi.yml
+++ b/test-ubi.yml
@@ -82,7 +82,7 @@ commandTests:
   - name: "Postgres version"
     command: "pg_dump"
     args: ["--version"]
-    expectedOutput: ["^pg_dump \\(PostgreSQL\\) 10.17\n$"]
+    expectedOutput: ["^pg_dump \\(PostgreSQL\\) 10.16\n$"]
   # bundler tests
   - name: "bundler version"
     command: "bundler"

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -16,9 +16,9 @@ RUN yum -y update-to nettle-3.4.1-4.el8_3.x86_64 gnutls-3.6.14-8.el8_3.x86_64
 RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
 ### Install openssl, postgresql client
     yum install -y openssl && \
-    yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm && \
-    yum install -y postgresql10 \
-                   postgresql10-devel
+    yum install -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/postgresql10-libs-10.16-1PGDG.rhel8.x86_64.rpm \
+                   https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/postgresql10-10.16-1PGDG.rhel8.x86_64.rpm \
+                   https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/postgresql10-devel-10.16-1PGDG.rhel8.x86_64.rpm
 
 ## Copy ruby binaries from ubi-ruby-builder
 RUN mkdir -p /var/lib/ruby/

--- a/ubi-ruby-fips/README.md
+++ b/ubi-ruby-fips/README.md
@@ -3,7 +3,7 @@ This container image includes UBI version `8` which contains the following packa
 
 * OpenSSL version `1.1.1c`: with FIPS 140-2 compliant OpenSSL module from RedHat UBI 8.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * Bundler version `2.1.4`.
  
 

--- a/ubuntu-ruby-fips/Description.md
+++ b/ubuntu-ruby-fips/Description.md
@@ -5,7 +5,7 @@ This image includes the following packages:
 
 * OpenSSL version `1.0.2u`: built with  FIPS 140-2 compliant OpenSSL module version `2.0.16`.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * Bundler version `2.1.4`.
  
 Source code: https://github.com/cyberark/conjur-base-image

--- a/ubuntu-ruby-fips/README.md
+++ b/ubuntu-ruby-fips/README.md
@@ -3,7 +3,7 @@ This container image includes Ubuntu version `20.04` which contains the followin
 
 * OpenSSL version `1.0.2u`: built with  FIPS 140-2 compliant OpenSSL module version: `2.0.16`.
 * Ruby version `2.5`: compiled against the FIPS 140-2 compliant OpenSSL module.
-* Postgres client version `10-10.17`: compiled against the FIPS 140-2 compliant OpenSSL module.
+* Postgres client version `10-10.16`: compiled against the FIPS 140-2 compliant OpenSSL module.
 * Bundler version `2.1.4`.
  
 


### PR DESCRIPTION
### What does this PR do?

1. Build was failing because the ubi-ruby-fips is now getting Postgres client version 10.18 from the yum repo. The repo should have had a pinned ubi-ruby-fips Postgres client version to avoid that. 
2. A previous PR to roll back the Postgres client version to 10.16 to match Conjur, https://github.com/cyberark/conjur-base-image/pull/59, missed out the ubi-ruby-fips image.

This PR fixes the build failures by pinning the Postgres client version for ubi-ruby-fips, and completes the roll back of Postgres client version to 10.16 to match Conjur.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
