### PR TITLE
Bump Nginx version to `1.20`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Security
+- Bump nginx from 1.14 to 1.20 to resolve CVE-2021-23017.
+  [cyberark/conjur-base-image#69](https://github.com/cyberark/conjur-base-image/pull/69)
+
 ## [1.0.5] - 2021-11-09
 
 ### Changed

--- a/ubi-nginx/Dockerfile
+++ b/ubi-nginx/Dockerfile
@@ -17,11 +17,9 @@ LABEL name="ubi-nginx" \
       summary="UBI-based Nginx image for use with Conjur" \
       description="UBI-based Nginx image for use with Conjur"
 
-# Upgrade packages to resolve CVE-2021-20305
-RUN yum -y update-to nettle-3.4.1-4.el8_3.x86_64 gnutls-3.6.14-8.el8_3.x86_64 
-
 # Install nginx version and
-RUN yum -y module enable nginx:$NGINX_VERSION && \
+RUN yum -y update && \
+    yum -y module enable nginx:$NGINX_VERSION && \
     INSTALL_PKGS="bind-utils \
                   gettext \
                   hostname \

--- a/ubi-nginx/build.sh
+++ b/ubi-nginx/build.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 # Needs to be kept as close as possible to appliance's NGINX version.
-NGINX_VERSION=1.14
+NGINX_VERSION=1.20
 
 docker build -t ubi-nginx:latest \
   --build-arg NGINX_VERSION="${NGINX_VERSION}" .

--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 
 . ../push.sh
 
-NGINX_VERSION=1.14
+NGINX_VERSION=1.20
 LOCAL_IMAGE="ubi-nginx:latest"
 IMAGE="conjur-nginx"
 REDHAT_IMAGE="scan.connect.redhat.com/ospid-9a3dab9b-64c4-4384-882c-80f26ce98607/${IMAGE}"

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -9,11 +9,9 @@ FROM ubi-ruby-builder:$RUBY_BUILDER_TAG as ubi-ruby-builder
 FROM registry.access.redhat.com/$UBI_VERSION/ubi
 ARG BUNDLER_VERSION
 
-# Upgrade packages to resolve CVE-2021-20305
-RUN yum -y update-to nettle-3.4.1-4.el8_3.x86_64 gnutls-3.6.14-8.el8_3.x86_64 
-
+RUN yum -y update && \
 ### We need libreadline-dev for its readline capabilities
-RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
+    yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
 ### Install openssl, postgresql client
     yum install -y openssl && \
     yum install -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/postgresql10-libs-10.16-1PGDG.rhel8.x86_64.rpm \


### PR DESCRIPTION
### Desired Outcome

This update resolves the vulnerability CVE-2021-23017, which was present in Nginx 1.18 and fixed in 1.20.1.

### Implemented Changes

- Changed nginx version from 1.14 to 1.20.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
