### PR TITLE
Update ubi-ruby-builder readline-devel reference

### DIFF
--- a/ubi-ruby-builder/Dockerfile
+++ b/ubi-ruby-builder/Dockerfile
@@ -15,8 +15,7 @@ RUN yum install -y --setopt=tsflags=nodocs gcc \
                                            openssl-devel \
                                            wget \
                                            zlib-devel
-RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm
-
+RUN yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm
 
 ## Compile ruby
 RUN wget --quiet https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR_VERSION/ruby-$RUBY_FULL_VERSION.tar.gz && \

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -11,7 +11,7 @@ ARG BUNDLER_VERSION
 
 RUN yum -y update && \
 ### We need libreadline-dev for its readline capabilities
-    yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
+    yum install -y --setopt=tsflags=nodocs http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/readline-devel-7.0-10.el8.x86_64.rpm && \
 ### Install openssl, postgresql client
     yum install -y openssl && \
     yum install -y https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/postgresql10-libs-10.16-1PGDG.rhel8.x86_64.rpm \


### PR DESCRIPTION
The `centos/8/BaseOS` repo appears to be 404'd. replaced this with `centos/8-stream/BaseOS`.
This change affects the following images:

- ubi-ruby-builder
- ubi-ruby-fips

### Desired Outcome

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?  Feel free to copy
this information from the connected issue.*

The building of the ruby images no longer fails due to the HTTP 404 error code for the readline-devel package.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_

  1. To resolve a broken pipeline

- _How should the reviewer approach this PR, especially if manual tests are required?_

  1. Verify that the change to the source repo for this package is adequate

- _Are there relevant screenshots you can add to the PR description?_

  N/A

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16716](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16716)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
