### PR TITLE
Revert back to phusion 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Upgrade Phusion to focal-1.2.0
-  [cyberark/conjur-base-image#82](https://github.com/cyberark/conjur-base-image/pull/82)
 - Upgrade Ruby to 3.0.4
   [cyberark/conjur-base-image#81](https://github.com/cyberark/conjur-base-image/pull/81)
 - Upgrade OpenSSL version from 1.0.2u to 1.0.2zd.

--- a/phusion-openldap-builder/build.sh
+++ b/phusion-openldap-builder/build.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PHUSION_VERSION=focal-1.2.0
+PHUSION_VERSION=0.11
 OPENLDAP_VERSION=2.4.46
 
 docker build -t phusion-openldap-builder:"$OPENLDAP_VERSION-fips" \

--- a/phusion-ruby-builder/build.sh
+++ b/phusion-ruby-builder/build.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PHUSION_VERSION=focal-1.2.0
+PHUSION_VERSION=0.11
 RUBY_MAJOR_VERSION=3.0
 RUBY_FULL_VERSION=3.0.4
 

--- a/phusion-ruby-fips/Dockerfile
+++ b/phusion-ruby-fips/Dockerfile
@@ -20,9 +20,7 @@ RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y libreadline-dev
 
-RUN apt-get purge -y --auto-remove openssl && \
-    apt-get purge -y --auto-remove libssl1.1 && \
-    apt-get purge -y --auto-remove libldap-2.4.2 libldap-common
+RUN apt-get purge -y --auto-remove openssl libssl1.1 libldap-2.4.2
 # Install the FIPS compliant OpenSSL
 ## Copy to binary from openssl builder
 COPY --from=OpenSSL-builder /usr/local/ssl/ /usr/local/ssl/

--- a/phusion-ruby-fips/README.md
+++ b/phusion-ruby-fips/README.md
@@ -1,5 +1,5 @@
 # Phusion container image
-This container image includes Phusion version `focal-1.2.0` which contains the following packages:
+This container image includes Phusion version `0.11` which contains the following packages:
 
 * OpenSSL version `1.0.2u`: built with  FIPS 140-2 compliant OpenSSL module version: `2.0.16`.
 * Ruby version `3.0.4`: compiled against the FIPS 140-2 compliant OpenSSL module.

--- a/phusion-ruby-fips/build.sh
+++ b/phusion-ruby-fips/build.sh
@@ -3,7 +3,7 @@
 cd "$(dirname "$0")"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PHUSION_VERSION=focal-1.2.0
+PHUSION_VERSION=0.11
 RUBY_BUILDER_TAG=3.0.4-fips
 PG_BUILDER_TAG=10-10.16-fips
 OPENLDAP_BUILDER_TAG=2.4.46-fips

--- a/phusion-ruby-fips/push.sh
+++ b/phusion-ruby-fips/push.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 
 . ../push.sh
 
-PHUSION_VERSION=focal-1.2.0
+PHUSION_VERSION=0.11
 LOCAL_IMAGE="phusion-ruby-fips:latest"
 IMAGE="cyberark/phusion-ruby-fips"
 REGISTRY="$(normalize_repo_name "$1")"


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome
Revert back to phusion 0.11. Focal-1.2.0 leads to failed appliance, debify & conjur builds as dependencies can't be installed (seem to be trying to go to openssl 1.1.1, so probably something needs to be pinned). I don't have the opportunity to explore all that before 12.6 release, so putting everything back so the other builds pass. 

### Implemented Changes

Undid all the changes in #82 

