### PR TITLE
Clear and rebuild UBI repo metadata

### DIFF
--- a/ubi-nginx/Dockerfile
+++ b/ubi-nginx/Dockerfile
@@ -17,6 +17,8 @@ LABEL name="ubi-nginx" \
       summary="UBI-based Nginx image for use with Conjur" \
       description="UBI-based Nginx image for use with Conjur"
 
+RUN yum -y clean all && yum -y makecache
+
 # Install nginx version and
 RUN yum -y update && \
     yum -y module enable nginx:$NGINX_VERSION && \

--- a/ubi-ruby-builder/Dockerfile
+++ b/ubi-ruby-builder/Dockerfile
@@ -9,6 +9,8 @@ ARG RUBY_MAJOR_VERSION
 ARG RUBY_FULL_VERSION
 ARG RUBY_SHA256=70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b
 
+RUN yum -y clean all && yum -y makecache && yum -y update
+
 RUN yum install -y --setopt=tsflags=nodocs gcc \
                                            gcc-c++ \
                                            make \


### PR DESCRIPTION
### Desired Outcome

Fixes an issue where downstream image consumers can not install packages due to stale RPM package cache

### Implemented Changes

`RUN yum -y clean all && yum -y makecache && yum -y update` before doing anything else

### Connected Issue/Story

Resolves N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
