### PR TITLE
Include internal registry when publishing ubi-nginx

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -19,8 +19,8 @@ if [[ -z "${REGISTRY:-}" ]]; then
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
-else
-  # Push to internal locations with VERSION and image versions
-  tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}-${TAG}"
-  tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}"
 fi
+
+# Push to internal locations with VERSION and image versions
+tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}-${TAG}"
+tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}"


### PR DESCRIPTION
Release build of conjur-base-image only publishes the conjur-nginx image to redhat.  This will publish internally each time as well.