### PR TITLE
Fully remove pushing ubi-nginx

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -1,26 +1,28 @@
 #!/bin/bash -e
 
-cd "$(dirname "$0")"
+# COMMENTED OUT TEMPORARILY TO GET BUILD PASSING. WILL ADDRESS SHORTLY.
 
-. ../push.sh
+# cd "$(dirname "$0")"
 
-NGINX_VERSION=1.20
-LOCAL_IMAGE="ubi-nginx:latest"
-IMAGE="conjur-nginx"
-# REDHAT_IMAGE="scan.connect.redhat.com/ospid-9a3dab9b-64c4-4384-882c-80f26ce98607/${IMAGE}"
-REGISTRY="$(normalize_repo_name "$1")"
-TAG=$(<../VERSION)
+# . ../push.sh
 
-if [[ -z "${REGISTRY:-}" ]]; then
-  # Push to public registry with VERSION
-  # if summon -f ../secrets.yml bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
-  #   tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
-  # else
-  #   echo 'Failed to log in to scan.connect.redhat.com'
-  #   exit 1
-  # fi
-else
-  # Push to internal locations with VERSION and image versions
-  tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}-${TAG}"
-  tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}"
-fi
+# NGINX_VERSION=1.20
+# LOCAL_IMAGE="ubi-nginx:latest"
+# IMAGE="conjur-nginx"
+# # REDHAT_IMAGE="scan.connect.redhat.com/ospid-9a3dab9b-64c4-4384-882c-80f26ce98607/${IMAGE}"
+# REGISTRY="$(normalize_repo_name "$1")"
+# TAG=$(<../VERSION)
+
+# if [[ -z "${REGISTRY:-}" ]]; then
+#   # Push to public registry with VERSION
+#   if summon -f ../secrets.yml bash -c 'docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"'; then
+#     tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
+#   else
+#     echo 'Failed to log in to scan.connect.redhat.com'
+#     exit 1
+#   fi
+# else
+#   # Push to internal locations with VERSION and image versions
+#   tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}-${TAG}"
+#   tag_and_push "${LOCAL_IMAGE}" "${REGISTRY}${IMAGE}:${NGINX_VERSION}"
+# fi


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Comments out all pushing for ubi-nginx to temporarily get the other images built so we can check the impact of OpenSSL on downstream builds (none of which require ubi-nginx, it seems). We'll restore pushing to RedHat shortly.