### PR TITLE
Put server first in login

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -21,7 +21,7 @@ TAG=$(<../VERSION)
 
 if [[ -z "${REGISTRY:-}" ]]; then
   # Push to public registry with VERSION
-  if summon -f ../secrets.yml bash -c "docker login -u ${user} -p ${REDHAT_API_KEY} ${REDHAT_REGISTRY}"; then
+  if summon -f ../secrets.yml bash -c "docker login ${REDHAT_REGISTRY} -u ${user} -p ${REDHAT_API_KEY}"; then
     tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
   else
     echo 'Failed to log in to quay.io'


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Make the Red Hat push try to login to redhat, not docker.io.

### Implemented Changes

Put the server name first again in the login command, in accordance with the help text.