### PR TITLE
Escape the Summon env var for later replace

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -23,7 +23,7 @@ TAG=$(<../VERSION)
 
 if [[ -z "${REGISTRY:-}" ]]; then
   # Push to public registry with VERSION
-  if summon -f ../secrets.yml bash -c 'echo ${REDHAT_API_KEY} | docker login ${REDHAT_REGISTRY} -u ${user} --password-stdin'; then
+  if summon -f ../secrets.yml bash -c "docker login ${REDHAT_REGISTRY} -u ${user} -p \${REDHAT_API_KEY}"; then
     tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
   else
     echo 'Failed to log in to quay.io'


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Get the ubi-nginx push.sh script to log in to quay.io for redhat. 

### Implemented Changes

Got the quoting and escaping right so the variables get populated at the correct time - local variables in the script right away, and the env var set by summon once the actual docker login is executed.  Thanks to @ismarc for figuring out the right set.