### PR TITLE
Remove from trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -87,3 +87,8 @@ CVE-2020-1971
 #
 # Performed by @jtuttle, approved by @andytinkham
 CVE-2021-3449
+
+# We have the fix for this CVE in place. However, trivy still detects
+# it because it doesn't handle the 1.0.2 line available only by premium 
+# support and thus thinks we're still vulnerable. 
+CVE-2023-0286

--- a/.trivyignore
+++ b/.trivyignore
@@ -87,6 +87,3 @@ CVE-2020-1971
 #
 # Performed by @jtuttle, approved by @andytinkham
 CVE-2021-3449
-
-# Temporarily ignore CVE-2023-0286 until OpenSSL is updated in the base image
-CVE-2023-0286


### PR DESCRIPTION
### Desired Outcome

Update the .trivyignore comment for CVE-2023-0286 because while we have the fix, trivy doesn't recognize it. (It assumes we need the 1.1.1 line fix because it doesn't account for 1.0.2 still being updated through premium support.)