### PR TITLE
Publish latest tag to Redhat on promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - Bumped Ruby version from 2.5.1 to 2.5.8 to address [CVE-2020-10663](https://nvd.nist.gov/vuln/detail/CVE-2020-10663).
 
-[Unreleased]: https://github.com/cyberark/conjur-base-image/compare/v2.0.3...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-base-image/compare/v2.0.6...HEAD
+[2.0.6]: https://github.com/cyberark/conjur-base-image/compare/v2.0.4...v2.0.6
+[2.0.4]: https://github.com/cyberark/conjur-base-image/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/cyberark/conjur-base-image/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/cyberark/conjur-base-image/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/cyberark/conjur-base-image/compare/v2.0.0...v2.0.1

--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -26,6 +26,9 @@ if [[ -z "${REGISTRY:-}" ]]; then
   if summon -f ../secrets.yml bash -c "docker login ${REDHAT_REGISTRY} -u ${user} -p \${REDHAT_API_KEY}"; then
     tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
     "./bin/scan_redhat_image" "${REDHAT_IMAGE}:${TAG}" "${prefixless}"
+
+    # Push latest tag to RH
+    tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:latest"
   else
     echo 'Failed to log in to quay.io'
     exit 1


### PR DESCRIPTION
### Desired Outcome

Fix tagging of Redhat images.

### Implemented Changes

Currently we are only publishing the version tagged image, so `latest` is never updated when new images are pushed to the RH registry

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
