### PR TITLE
Update ubi-ruby-fips path to match new pg version

### DIFF
--- a/postgres-client-builder/Dockerfile
+++ b/postgres-client-builder/Dockerfile
@@ -34,7 +34,7 @@ RUN wget https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
 
 ## Compile postgres client
 RUN cd postgresql-$PG_VERSION && \
-    env CC=gcc CPPFLAGS=-I/usr/local/ssl/include LDFLAGS=-L/usr/local/ssl/lib ./configure --with-openssl --without-readline --prefix=/usr/local/pgsql  && \
+    env CC=gcc CPPFLAGS=-I/usr/local/ssl/include LDFLAGS=-L/usr/local/ssl/lib ./configure --with-ssl=openssl --without-readline --prefix=/usr/local/pgsql  && \
     cd - && \
     cd postgresql-$PG_VERSION/src/interfaces && \
     make && \

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y update && \
 ## Copy ruby binaries from ubi-ruby-builder
 RUN mkdir -p /var/lib/ruby/
 COPY --from=ubi-ruby-builder /var/lib/ruby/ /var/lib/ruby/
-ENV PATH="/usr/pgsql-10/bin:/var/lib/ruby/bin:${PATH}"
+ENV PATH="/usr/pgsql-15/bin:/var/lib/ruby/bin:${PATH}"
 
 ## Install Ruby tools
 RUN gem install --no-document bundler:$BUNDLER_VERSION


### PR DESCRIPTION
### Desired Outcome
Small path change missed in the postgres 15 upgrade PR which caused compile issues downstream. Also changes postgres builder to use the recommended --with-ssl=openssl flag in place of --with-openssl.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
