### PR TITLE
Make daily build a release build to get changes downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.0.7] - 2023-05-16
 
 ### Changed
+- Changed daily build to release the base images so we get the latest versions of
+  unpinned dependencies quickly
+  [cyberark/conjur-base-image#117](https://github.com/cyberark/conjur-base-image/pull/117)
 - Update Postgres to version 15.3 in all base images.
   [cyberark/conjur-base-image#113](https://github.com/cyberark/conjur-base-image/pull/113)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   }
 
   triggers {
-    cron(getDailyCronString())
+    parameterizedCron(getDailyCronString("%MODE=RELEASE"))
   }
 
   stages {


### PR DESCRIPTION
### Desired Outcome

Get changes that come from unpinned versions downstream faster.

### Implemented Changes

Make each daily build a release build so that the images are published. Previously, the only automatic release builds were when PRs were merged to main, which meant it could be a while before we got the latest versions of the dependencies. Since all the downstream projects pull the latest release version, they'll immediately pick up the changes as well. 

