### PR TITLE
Avoid pushing latest tag to Redhat

### DIFF
--- a/ubi-nginx/push.sh
+++ b/ubi-nginx/push.sh
@@ -26,9 +26,6 @@ if [[ -z "${REGISTRY:-}" ]]; then
   if summon -f ../secrets.yml bash -c "docker login ${REDHAT_REGISTRY} -u ${user} -p \${REDHAT_API_KEY}"; then
     tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:${TAG}"
     "./bin/scan_redhat_image" "${REDHAT_IMAGE}:${TAG}" "${prefixless}"
-
-    # Push latest tag to RH
-    tag_and_push "${LOCAL_IMAGE}" "${REDHAT_IMAGE}:latest"
   else
     echo 'Failed to log in to quay.io'
     exit 1


### PR DESCRIPTION
### Desired Outcome

Turns out this script runs on release builds rather than promotions. This is resulting in frequent overwrites to the `latest` tag, and also requires manually publishing the image from the Redhat catalog before the tagged image becomes publicly available.

We have also been advised by infra to avoid using the `latest` tag going forward based on guidance from Redhat

### Implemented Changes

Remove step that pushes `latest` tag to RH

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
