### PR TITLE
Update trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -92,3 +92,9 @@ CVE-2021-3449
 # it because it doesn't handle the 1.0.2 line available only by premium 
 # support and thus thinks we're still vulnerable. 
 CVE-2023-0286
+
+# Scanners have started flagging CVE-2017-14033 because they are matching 
+# the version of Ruby that shipped the vulnerable openssl gem with the 
+# version of openssl itself. We use Ruby 3 in our base images, so already
+# have the fix for this issue.
+CVE-2017-14033

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -32,6 +32,3 @@ ENV PATH="/usr/pgsql-15/bin:/var/lib/ruby/bin:${PATH}"
 
 ## Install Ruby tools
 RUN gem install --no-document bundler:$BUNDLER_VERSION
-
-## Remove private keys included for Perl IO since we don't use them
-RUN rm -rf /usr/share/doc/perl-IO-Socket-SSL/certs/* 

--- a/ubi-ruby-fips/Dockerfile
+++ b/ubi-ruby-fips/Dockerfile
@@ -32,3 +32,6 @@ ENV PATH="/usr/pgsql-15/bin:/var/lib/ruby/bin:${PATH}"
 
 ## Install Ruby tools
 RUN gem install --no-document bundler:$BUNDLER_VERSION
+
+## Remove private keys included for Perl IO since we don't use them
+RUN rm -rf /usr/share/doc/perl-IO-Socket-SSL/certs/* 


### PR DESCRIPTION
### Desired Outcome

Stop trivy failures for CVE-2017-14033 because we already have the fix.