### PR TITLE
CNJR-2705: fix ubuntu postgres version unpin

### DIFF
--- a/ubuntu-ruby-fips/Dockerfile
+++ b/ubuntu-ruby-fips/Dockerfile
@@ -36,19 +36,25 @@ FROM ubuntu:${UBUNTU_VERSION} as ubuntu-ruby-fips-slim
 ARG PG_VERSION
 ARG RUBY_HOME=/var/lib/ruby
 
-COPY apt/keyrings/ /etc/apt/keyrings/
-RUN apt-get update && \
-    apt-get install -y gnupg && \
-    for f in /etc/apt/keyrings/*.pub; do \
-      file=$(basename -- "$f"); gpg --dearmor < $f > /etc/apt/keyrings/${file%.*}.gpg; rm $f; \
-    done;
-COPY apt/sources.list.d/ /etc/apt/sources.list.d/
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=Etc/UTC \
     BUNDLE_SILENCE_ROOT_WARNING=1 \
     LANG=C.UTF-8 \
     PATH="${RUBY_HOME}/bin:${PATH}" \
-    RUBY_HOME=${RUBY_HOME}
+    RUBY_HOME=${RUBY_HOME} \
+    PG_VERSION=${PG_VERSION}
+
+COPY apt/ /etc/apt/
+RUN apt-get update && \
+    apt-get install -y gnupg && \
+    for f in /etc/apt/keyrings/*.pub; do \
+      file=$(basename -- "$f"); gpg --dearmor < "$f" > "/etc/apt/keyrings/${file%.*}.gpg"; rm "$f"; \
+    done && \
+    . /etc/os-release && \
+    PG_MAJOR_VERSION=${PG_VERSION%%.*} && \
+    for f in /etc/apt/sources.list.d/*.template; do \
+      file=$(basename -- "$f"); while read line; do eval echo \"$line\"; done < "$f" > "/etc/apt/sources.list.d/${file%.*}.list"; rm "$f"; \
+    done
 
 RUN apt-get update && \
     export PG_MAJOR_VERSION=$(if [ -z "${PG_VERSION}" ]; then apt-cache madison libpq5 | sed -n 's/^ *libpq5 *| *\([0-9]*\)\.[0-9]*-.*$/\1/p' | sort -Vr | head -1; else echo "${PG_VERSION%%.*}"; fi) && \

--- a/ubuntu-ruby-fips/apt/sources.list.d/nginx.list
+++ b/ubuntu-ruby-fips/apt/sources.list.d/nginx.list
@@ -1,2 +1,0 @@
-deb [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/ubuntu/ jammy nginx
-deb-src [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/ubuntu/ jammy nginx

--- a/ubuntu-ruby-fips/apt/sources.list.d/nginx.template
+++ b/ubuntu-ruby-fips/apt/sources.list.d/nginx.template
@@ -1,0 +1,2 @@
+deb [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/ubuntu/ ${VERSION_CODENAME} nginx
+deb-src [signed-by=/etc/apt/keyrings/nginx.gpg] http://nginx.org/packages/ubuntu/ ${VERSION_CODENAME} nginx

--- a/ubuntu-ruby-fips/apt/sources.list.d/pgdg.list
+++ b/ubuntu-ruby-fips/apt/sources.list.d/pgdg.list
@@ -1,1 +1,0 @@
-deb [arch=amd64,arm64 signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt jammy-pgdg main

--- a/ubuntu-ruby-fips/apt/sources.list.d/postgres.template
+++ b/ubuntu-ruby-fips/apt/sources.list.d/postgres.template
@@ -1,0 +1,1 @@
+deb [signed-by=/etc/apt/keyrings/postgres.gpg] http://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main ${PG_MAJOR_VERSION}


### PR DESCRIPTION
### Desired Outcome

It turns out that postgres APT repo organization is not that simple, the main provide libpq5 and libpq-dev only in the latest version. There is a version specific repo containing appropriate versions of those libs but they do not provide postgres server package with a major version.

### Implemented Changes

In case the postgres version is pinned (to major or mainor) we need to provide both APT repos main and specific major version.

### Connected Issue/Story

CyberArk internal issue ID: CNJR-2705

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
