### PR TITLE
make setuser interactive when called from a terminal

### DIFF
--- a/ubuntu-ruby-fips/setuser/main.go
+++ b/ubuntu-ruby-fips/setuser/main.go
@@ -31,9 +31,21 @@ func main() {
 		fmt.Sprintf("HOME=%s", u.HomeDir),
 	)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if isTerminal(os.Stdin) {
+		cmd.Stdin = os.Stdin
+	}
 	if err = cmd.Run(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// isTerminal returns true if the given file is a terminal.
+func isTerminal(stdin *os.File) bool {
+	fi, err := stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
 func help() string {


### PR DESCRIPTION
### Desired Outcome

Allow the setuser to become interactive in case the terminal is available. That could be useful in case of user has a session and wants to use an interactive tool like psql.

### Implemented Changes

Check if stdin is an active terminal and then pass it to the command execution. In case the session is non interactive stdin is not passed to avoid "inappropriate ioctl for device" error

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
