### PR TITLE
Proposal: Bump ruby to 3.3.1

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -12,7 +12,7 @@ Section 1: Apache-2.0
 
 Section 2: BSD-2-Clause
 >>> https://github.com/nginx/nginx v1.20
->>> https://github.com/ruby/ruby v3.2
+>>> https://github.com/ruby/ruby v3.3
 
 Section 3: PostgreSQL License
 >>> https://github.com/postgres/postgres v15_3

--- a/test-ubi-ruby-fips.yml
+++ b/test-ubi-ruby-fips.yml
@@ -38,7 +38,7 @@ commandTests:
   - name: "Ruby version"
     command: "ruby"
     args: ["--version"]
-    expectedOutput: ["^ruby 3.2.2 \\(2023-03-30 revision e51014f9c0\\) \\[x86_64-linux\\]\n$"]
+    expectedOutput: ["^ruby 3.3.1 \\(2024-04-23 revision c56cd86388\\) \\[x86_64-linux\\]\n$"]
   - name: "Ruby linked with valid libcrypto.so version"
     setup: [["dnf", "install", "-y", "binutils"]]
     command: "bash"

--- a/test-ubuntu-ruby-fips.yml
+++ b/test-ubuntu-ruby-fips.yml
@@ -52,7 +52,7 @@ commandTests:
   - name: "Ruby version"
     command: "ruby"
     args: ["--version"]
-    expectedOutput: ["^ruby 3.2.2 \\(2023-03-30 revision e51014f9c0\\) \\[x86_64-linux\\]\n$"]
+    expectedOutput: ["^ruby 3.3.1 \\(2024-04-23 revision c56cd86388\\) \\[x86_64-linux\\]\n$"]
   - name: "Ruby linked with valid libcrypto.so version"
     setup: [["apt-get", "update"], ["apt-get", "install", "-y", "binutils"]]
     command: "bash"

--- a/test-ubuntu-ruby-postgres-fips.yml
+++ b/test-ubuntu-ruby-postgres-fips.yml
@@ -52,7 +52,7 @@ commandTests:
   - name: "Ruby version"
     command: "ruby"
     args: ["--version"]
-    expectedOutput: ["^ruby 3.2.2 \\(2023-03-30 revision e51014f9c0\\) \\[x86_64-linux\\]\n$"]
+    expectedOutput: ["^ruby 3.3.1 \\(2024-04-23 revision c56cd86388\\) \\[x86_64-linux\\]\n$"]
   - name: "Ruby linked with valid libcrypto.so version"
     setup: [["apt-get", "update"], ["apt-get", "install", "-y", "binutils"]]
     command: "bash"

--- a/versions.env
+++ b/versions.env
@@ -1,8 +1,8 @@
 UBUNTU_VERSION=22.04
 UBI_VERSION=ubi9
-RUBY_FULL_VERSION=3.2.2
-RUBY_MAJOR_VERSION=3.2
-RUBY_SHA256=96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc
+RUBY_FULL_VERSION=3.3.1
+RUBY_MAJOR_VERSION=3.3
+RUBY_SHA256=8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99
 # The empty PG_VERSION would take the latest available version, to pin to a major pass just the number e.g. '15' in case of pinning to minor full version is needed e.g '15.3'
 PG_VERSION=15
 OPEN_SSL_FIPS_PROVIDER_VERSION=3.0.9


### PR DESCRIPTION
### Desired Outcome

Hello, I came across your wonderful project and I am curious on trying it out to see if we can use the same doe ubuntu based ruby image compiled with FIPS for a Rails app. I'd like to propose an upgrade to ruby 3.3.1 if that sounds like a good idea, as it would allow me to test it with an existing app :).

Thank you for your work and review. 

### Implemented Changes

I have updated all the references from Ruby 3.2.2 to Ruby 3.3.1 and update the SHA accordingly. 

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

Note: I wasn't sure whats the best way to update the Changelog since this is still a proposal PR and there is no version cut for it yet.

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [X] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [X] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
